### PR TITLE
Exclude schema and templates

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -9,6 +9,9 @@
 
 AllCops:
   TargetRubyVersion: 2.4
+  Exclude:
+    - 'lib/templates/**/*'
+    - 'db/schema.rb'
 
 #
 # Ruby Cops


### PR DESCRIPTION
Exclude `schema.rb`. We don't need to lint generated files.
Exclude `lib/templates/**.*`. These are not actually ruby files. They have symbols that fail the linter.